### PR TITLE
fix: Don't panic when parsing Color fields

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -235,8 +235,14 @@ fn define_entities(ldtk_entities: &[EntityDefinition]) -> TokenStream {
 
                     #(
                         let tmp: Option<Result<Option<#custom_types>,_>> = instances.iter().find(|field| field.identifier == #custom_idents)
-                            .map(|field| field.value.as_ref())
-                            .map(|value| value.map(|value| ::bevy_spicy_ldtk::private::parse_field(value)).transpose());
+                            .map(|field| {
+                                field.value.as_ref()
+                                    .map(|value| match field.field_instance_type.as_ref() {
+                                        "Color" => ::bevy_spicy_ldtk::private::parse_color(value),
+                                        _ => ::bevy_spicy_ldtk::private::parse_field(value)
+                                    })
+                                    .transpose()
+                            });
 
                         #custom_names = match tmp {
                             None => return Err(::bevy_spicy_ldtk::error::LdtkError::MissingFieldsForEntities),

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@
 pub enum LdtkError {
     #[error("An error occured while deserializing")]
     Json(#[from] serde_json::Error),
+    #[error("An error occured while parsing a color")]
+    HexColor(#[from] bevy::render::color::HexColorError),
     #[error("One or more fields are missing in the LDTK file")]
     MissingFieldsForEntities,
     #[error("One or more fields are missing in the LDTK file")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,4 +372,9 @@ pub mod private {
     pub fn parse_field<T: DeserializeOwned>(field: &serde_json::Value) -> LdtkResult<T> {
         Ok(serde_json::from_value(field.clone())?)
     }
+
+    pub fn parse_color(field: &serde_json::Value) -> LdtkResult<bevy::render::color::Color> {
+        let hex: String = serde_json::from_value(field.clone())?;
+        Ok(bevy::render::color::Color::hex(&hex[1..])?)
+    }
 }


### PR DESCRIPTION
Bevy colors implement serde::Deserialize, but they do not expect hex
values, so trying to parse colors as serialized by ldtk would fail.

This adds a special-case to check the field type and handle it by going
though a string first.